### PR TITLE
Add EnergyLink features

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Much of the planned features are gated by progress on modding the game itself or
 - checklist box fillers as progression item
 - drop patches trap item
 - physics-based trap items (altitude increase/decrease, teleport forward/backward/random location, gravity changes, etc.)
-- energylink system for spending energy for patches
 
 #### Randomization
 - randomization of checklist box rewards

--- a/worlds/kirby_air_ride/DolphinInterface.py
+++ b/worlds/kirby_air_ride/DolphinInterface.py
@@ -105,7 +105,7 @@ class DolphinInterface:
         self.transitioned_time: float = time.time()
         self.transition_wait: int = 6
         self.transitioned: bool = False
-        pass
+        self.player_1_patches: dict[PatchType, float] = {key: 0 for key in PATCH_ADDRESS_MAP.keys()}
 
     def hook(self) -> bool:
         """
@@ -288,6 +288,13 @@ class DolphinInterface:
             if addr is not None:
                 current = self.read_float(addr)
                 self.write_float(addr, current + delta)
+
+    def update_player_patch_counts(self) -> None:
+        """
+        Read in the current player patch counts to self.player_1_patches.
+        """
+        for patch_type in self.player_1_patches:
+            self.player_1_patches[patch_type] = self.read_float(PATCH_ADDRESS_MAP[patch_type])
 
     def apply_effect_item(self, item_name: str) -> None:
         """

--- a/worlds/kirby_air_ride/KAROptions.py
+++ b/worlds/kirby_air_ride/KAROptions.py
@@ -123,6 +123,17 @@ class ProgressionFreeRun(Toggle):
     display_name = "Free Run checkboxes are progression"
 
 
+class EnergyLink(Toggle):
+    """
+    This enables or disables EnergyLink features. This means that collected patches will send energy
+    to the collective energy pool of the Multiworld. You can spend some of this energy to get specific patches
+    or other items immediately.
+    """
+
+    default = 0
+    display_name = "Energy Link"
+
+
 @dataclass
 class KAROptions(PerGameCommonOptions, DeathLinkMixin):
     """
@@ -140,6 +151,7 @@ class KAROptions(PerGameCommonOptions, DeathLinkMixin):
     permanent_patches: PermanentPatches
     permanent_patch_progression: PermanentPatchProgression
     free_run_progression: ProgressionFreeRun
+    energy_link: EnergyLink
 
     def get_output_dict(self) -> dict[str, Any]:
         """
@@ -164,6 +176,7 @@ class KAROptions(PerGameCommonOptions, DeathLinkMixin):
             "permanent_patch_progression",
             "free_run_progression",
             "death_link",
+            "energy_link",
         )
 
 

--- a/worlds/kirby_air_ride/docs/en_Kirby Air Ride.md
+++ b/worlds/kirby_air_ride/docs/en_Kirby Air Ride.md
@@ -77,7 +77,6 @@ Much of the planned features are gated by progress on modding the game itself or
 - checklist box fillers as progression item
 - drop patches trap item
 - physics-based trap items (altitude increase/decrease, teleport forward/backward/random location, gravity changes, etc.)
-- energylink system for spending energy for patches
 
 #### Randomization
 - randomization of checklist box rewards


### PR DESCRIPTION
Add /energylink and /energylink_spend commands. Getting patches in-game creates 1J of energy, and items can be bought for 10J each, or 90J for an All Patch. 